### PR TITLE
Add funding: PayPal sponsor link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# .github/FUNDING.yml
+# Support this project
+custom:
+  - https://www.paypal.com/paypalme/nickotmazgin


### PR DESCRIPTION
This adds .github/FUNDING.yml so the Sponsor button shows on the repo.

Links:
- PayPal: https://www.paypal.com/paypalme/nickotmazgin

Notes:
- GitHub renders a “Sponsor” button on the repository header.
- Only a custom link (PayPal) is configured for now; more providers can be added later.


