### PR TITLE
ci(codeql): add workflow + config; ignore asset paths

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ "main", "legacy/42-44" ]
+    paths-ignore:
+      - 'dist/**'
+      - 'screenshots/**'
+      - '**/*.png'
+      - '**/*.svg'
+      - '**/*.zip'
+  pull_request:
+    branches: [ "main", "legacy/42-44" ]
+    paths-ignore:
+      - 'dist/**'
+      - 'screenshots/**'
+      - '**/*.png'
+      - '**/*.svg'
+      - '**/*.zip'
+  schedule:
+    - cron: '21 1 * * 3'  # weekly
+
+jobs:
+  analyze:
+    name: CodeQL Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ "javascript" ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          config-file: codeql-config.yml
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -1,0 +1,10 @@
+name: Numeric Clock CodeQL
+paths:
+  - .
+paths-ignore:
+  - dist/**
+  - screenshots/**
+  - '**/gschemas.compiled'
+  - '**/*.png'
+  - '**/*.svg'
+  - '**/*.zip'


### PR DESCRIPTION
### What
- Add GitHub Actions CodeQL workflow (`.github/workflows/codeql.yml`)
- Add CodeQL config (`codeql-config.yml`) to ignore assets (screenshots, PNG/SVG, zips, gschemas.compiled, dist)

### Why
- Enable code scanning/security alerts for JS/GJS while keeping runs fast and noise low.

### How verified
- Workflow triggers on PRs/push to `main` (and weekly schedule).
- Uses `config-file: codeql-config.yml` so asset paths are excluded.

### Follow-ups
- After first green run on **main**, add the status check in Settings → Branches → main:
  - **Require status checks to pass** → add **CodeQL / Analyze (javascript)**  
  (or use **Require code scanning results → CodeQL** if the named check isn’t listed yet)
- If you want CodeQL on `legacy/42-44` too, backport this workflow to that branch (see note below).
### What
- Add GitHub Actions CodeQL workflow (`.github/workflows/codeql.yml`)
- Add CodeQL config (`codeql-config.yml`) to ignore assets (screenshots, PNG/SVG, zips, gschemas.compiled, dist)

### Why
- Enable code scanning/security alerts for JS/GJS while keeping runs fast and noise low.

### How verified
- Workflow triggers on PRs/push to `main` (and weekly schedule).
- Uses `config-file: codeql-config.yml` so asset paths are excluded.

### Follow-ups
- After first green run on **main**, add the status check in Settings → Branches → main:
  - **Require status checks to pass** → add **CodeQL / Analyze (javascript)**  
  (or use **Require code scanning results → CodeQL** if the named check isn’t listed yet)
- If you want CodeQL on `legacy/42-44` too, backport this workflow to that branch (see note below).
