### PR TITLE
docs: cross-link sibling GNOME extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,8 @@ MIT © Nick Otmazgin — see [LICENSE](LICENSE).
 **GitHub topics:** `gnome-shell-extension` · `clock` · `24-hour` · `numeric-date` · `top-bar` · `seconds` · `wayland` · `linux` · `open-source`
 
 **Search for:** GNOME numeric clock, Linux top bar date format, DD/MM/YYYY clock extension, 24 hour clock GNOME
+
+## More GNOME extensions by Nick Otmazgin
+
+- [ClipFlow Pro](https://github.com/nickotmazgin/clipflow-pro) — clipboard history manager with pins, stars & privacy
+- [Comfort Control (EaseHub)](https://github.com/nickotmazgin/comfort-control-easehub) — panel menu for power, screenshots, updates & utilities


### PR DESCRIPTION
Links all three GNOME extensions together for public discovery.

Made with [Cursor](https://cursor.com)