### PR TITLE
release: v17.3.1 — GNOME 46 fixes, live preview, clock restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,23 @@
 # Changelog
 
-## v17.3.0 — 2026-05-30
+## v17.3.1 — 2026-05-31
 
-### GNOME 45–50 (ESM, extension version 20)
+### GNOME 45–50 (ESM, extension version 21)
 
-- Add GNOME Shell 48, 49, and 50 to metadata.
-- GNOME Shell 46: use `child-added` / `child-removed` stage signals (GNOME 45 and earlier used `actor-added` / `actor-removed`).
-- Default format: `%d/%m/%Y %H:%M:%S` (DD/MM/YYYY, 24-hour, with seconds).
-- Default update interval: 1 second; smooth second tick enabled by default.
-- Add **Israel** preset in preferences (DD/MM/YYYY HH:MM:SS, top bar only).
-- Update README with latest release info, install steps, and Israel setup.
-- Remove stale SweetTooth `_generated` metadata field.
+- **Fix:** GNOME Shell 46 — connect only `child-added` / `child-removed` (never `actor-added` on MetaStage)
+- **Fix:** Restore GNOME default clock when extension is disabled or uninstalled
+- **Prefs:** Live preview ticks every second when format includes `%S` / `%T`
+- **Prefs:** Preset renamed to **DD/MM + seconds** (public preset for any timezone, not Israel-only)
+- Default `only-topbar`: **true** (lock screen clock unchanged by default)
+- **Supersedes v17.3.0 and earlier** — download only from [latest release](https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock/releases/latest)
 
-### Legacy 42–44 (extension version 18)
+## v17.3.0 — 2026-05-30 (superseded by v17.3.1)
 
-- Fix legacy ZIP packaging to include `schemas/gschemas.compiled`.
+- GNOME Shell 48–50 support; extension version 20
+- GNOME 46 stage signal migration (partial — use v17.3.1 for full fix)
+- Israel preset, DD/MM/YYYY defaults
+
+## Unreleased (merged into v17.3.1)
+
+- Restore GNOME default clock display when the extension is disabled or uninstalled.
+- Prefs: clarify DD/MM + seconds preset is for all users (system timezone), not Israel-only code.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 A lightweight GNOME Shell extension that replaces the top-bar clock with a **numeric, fully configurable** format — ideal for **DD/MM/YYYY** and **24-hour** time with optional **seconds**.
 
-**Latest:** v17.3.0 — ESM build v20 for **GNOME 45–50** (Shell 46 tested on Zorin OS 18.1)
+**Latest:** v17.3.1 — ESM build v21 for **GNOME 45–50** (Shell 46 tested on Zorin OS 18.1)
+
+> **Previous releases superseded** — download only [v17.3.1](https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock/releases/latest).
 
 **UUID:** `numeric-clock@nickotmazgin` · **License:** MIT
 
@@ -35,10 +37,11 @@ A lightweight GNOME Shell extension that replaces the top-bar clock with a **num
 
 * Fully numeric date/time — you choose the `strftime` **format string**
 * **Israel-friendly defaults:** `DD/MM/YYYY HH:MM:SS` (24-hour, seconds, system timezone e.g. `Asia/Jerusalem`)
-* **Instant-apply** preferences — changes apply as you type
+* **Live preview** in settings — ticks every second when format shows seconds
 * Configurable **update interval** (1–300 seconds)
 * **Smooth second tick** alignment when showing seconds
-* Presets: Default, Seconds (with weekday), Israel (top bar only)
+* Presets: Default, Seconds (with weekday), **DD/MM + seconds** (any timezone)
+* **Restore default clock** when disabled or uninstalled
 * Safe plain-text rendering (no Pango markup)
 * No network access, telemetry, or external services
 
@@ -48,7 +51,7 @@ A lightweight GNOME Shell extension that replaces the top-bar clock with a **num
 
 | Build (branch)              |     GNOME | Extension version | Packaging notes                                               |
 | --------------------------- | --------: | ----------------: | ------------------------------------------------------------- |
-| **Main** (`main`)           | **45–50** |                20 | Do not include `schemas/gschemas.compiled`. Metadata omits `icon`. |
+| **Main** (`main`)           | **45–50** |                21 | Do not include `schemas/gschemas.compiled`. Metadata omits `icon`. |
 | **Legacy** (`legacy/42-44`) | **42–44** |                18 | Must include `schemas/gschemas.compiled` inside the ZIP.      |
 
 ---
@@ -59,7 +62,7 @@ A lightweight GNOME Shell extension that replaces the top-bar clock with a **num
 
 ```bash
 # GNOME 45–50 (ESM)
-gnome-extensions install --force dist/numeric-clock@nickotmazgin.v20.shell-extension.zip
+gnome-extensions install --force dist/numeric-clock@nickotmazgin.v21.shell-extension.zip
 
 # GNOME 42–44 (legacy)
 gnome-extensions install --force dist/numeric-clock@nickotmazgin.v18.shell-extension.zip
@@ -73,7 +76,7 @@ gnome-extensions prefs numeric-clock@nickotmazgin
 ```bash
 ./tools/build.sh
 ./tools/validate.sh
-gnome-extensions install --force dist/numeric-clock@nickotmazgin.v20.shell-extension.zip
+gnome-extensions install --force dist/numeric-clock@nickotmazgin.v21.shell-extension.zip
 gnome-extensions enable numeric-clock@nickotmazgin
 ```
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -35,13 +35,28 @@ function allStageLabels() {
   return out;
 }
 
-function connectStageSignal(stage, modernSignal, legacySignal, callback) {
+function shellMajor() {
+  try {
+    const Config = imports.misc.config;
+    const ver = Config.PACKAGE_VERSION || '';
+    const major = parseInt(String(ver).split('.')[0], 10);
+    if (Number.isFinite(major) && major > 0)
+      return major;
+  } catch (_e) {}
+  return 46;
+}
+
+/** GNOME 45+ MetaStage uses child-*; older shells use actor-*. Never connect actor-* on 45+. */
+function connectStageSignal(stage, addedOrRemoved, callback) {
   if (!stage || typeof stage.connect !== 'function')
     return 0;
-  try { return stage.connect(modernSignal, callback); }
-  catch {
-    try { return stage.connect(legacySignal, callback); }
-    catch { return 0; }
+  const modern = addedOrRemoved === 'removed' ? 'child-removed' : 'child-added';
+  const legacy = addedOrRemoved === 'removed' ? 'actor-removed' : 'actor-added';
+  const sig = shellMajor() >= 45 ? modern : legacy;
+  try {
+    return stage.connect(sig, callback);
+  } catch (_e) {
+    return 0;
   }
 }
 
@@ -154,10 +169,8 @@ export default class NumericClockExtension extends Extension {
       this._settings.connect('changed::format-string', () => this._updateAllNow()),
       this._settings.connect('changed::update-interval', () => this._restartTimer()),
     );
-    this._stageAddedId = connectStageSignal(
-      global.stage, 'child-added', 'actor-added', () => this._updateAllNow());
-    this._stageRemovedId = connectStageSignal(
-      global.stage, 'child-removed', 'actor-removed', () => this._updateAllNow());
+    this._stageAddedId = connectStageSignal(global.stage, 'added', () => this._updateAllNow());
+    this._stageRemovedId = connectStageSignal(global.stage, 'removed', () => this._updateAllNow());
     this._restartTimer();
   }
 
@@ -181,6 +194,25 @@ export default class NumericClockExtension extends Extension {
     }
     this._textSignalIds = [];
 
+    this._restoreDefaultClocks();
     this._settings = null;
+  }
+
+  _restoreDefaultClocks() {
+    const dm = Main.panel?.statusArea?.dateMenu;
+    if (dm) {
+      for (const method of ['_updateClock', '_updateClockDisplay', '_update']) {
+        if (typeof dm[method] === 'function') {
+          try { dm[method](); break; } catch {}
+        }
+      }
+    }
+    for (const lab of this._collectClockLabels()) {
+      if (!lab || typeof lab.set_text !== 'function') continue;
+      try {
+        const ct = lab.clutter_text;
+        if (ct && ct[HOOKED]) delete ct[HOOKED];
+      } catch {}
+    }
   }
 }

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -10,8 +10,8 @@
     "49",
     "50"
   ],
-  "version": 20,
-  "version-name": "17.3 45.50",
+  "version": 21,
+  "version-name": "17.3.1 45.50",
   "settings-schema": "org.gnome.shell.extensions.numeric-clock",
   "gettext-domain": "numeric-clock",
   "url": "https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock",

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -24,18 +24,35 @@ export default class NumericClockPrefs extends ExtensionPreferences {
     rowFmt.activatable_widget = entry;
     group.add(rowFmt);
 
-    // Live preview
-    const rowPreview = new Adw.ActionRow({ title: _('Preview') });
+    // Live preview (ticks every second when format shows seconds)
+    const rowPreview = new Adw.ActionRow({
+      title: _('Preview'),
+      subtitle: _('Live clock sample — add %S or %T in the format string to show seconds'),
+    });
     const preview = new Gtk.Label({ hexpand: true, selectable: true, xalign: 1 });
+    let previewTimer = 0;
     function formatNow(fmt) {
       try { return GLib.DateTime.new_now_local().format(fmt); }
       catch (_) { return GLib.DateTime.new_now_local().format('%d/%m/%Y %H:%M:%S'); }
     }
+    function formatShowsSeconds(fmt) {
+      return /%[0-9]*S|%[0-9]*T|%\d*[EOe]/.test(fmt || '');
+    }
     function refreshPreview() {
-      preview.label = formatNow(settings.get_string('format-string'));
+      const fmt = settings.get_string('format-string');
+      preview.label = formatNow(fmt);
+      const intervalSec = settings.get_int('update-interval');
+      const tickMs = formatShowsSeconds(fmt) || intervalSec <= 1 ? 1000 : Math.max(1000, intervalSec * 1000);
+      if (previewTimer)
+        GLib.source_remove(previewTimer);
+      previewTimer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, tickMs, () => {
+        preview.label = formatNow(settings.get_string('format-string'));
+        return GLib.SOURCE_CONTINUE;
+      });
     }
     refreshPreview();
     settings.connect('changed::format-string', refreshPreview);
+    settings.connect('changed::update-interval', refreshPreview);
     rowPreview.add_suffix(preview);
     group.add(rowPreview);
 
@@ -67,10 +84,13 @@ export default class NumericClockPrefs extends ExtensionPreferences {
     group.add(rowSmooth);
 
     // Presets
-    const rowPresets = new Adw.ActionRow({ title: _('Presets') });
+    const rowPresets = new Adw.ActionRow({
+      title: _('Presets'),
+      subtitle: _('Quick formats for any timezone — uses your system clock (e.g. Asia/Jerusalem)'),
+    });
     const btnDefault = new Gtk.Button({ label: _('Default') });
     const btnSeconds = new Gtk.Button({ label: _('Seconds') });
-    const btnIsrael = new Gtk.Button({ label: _('Israel') });
+    const btnIsrael = new Gtk.Button({ label: _('DD/MM + seconds') });
     btnDefault.connect('clicked', () => {
       settings.set_string('format-string', '%d/%m/%Y %H:%M:%S');
       settings.set_int('update-interval', 1);

--- a/src/schemas/org.gnome.shell.extensions.numeric-clock.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.numeric-clock.gschema.xml
@@ -13,7 +13,7 @@
       <range min="1" max="300"/>
     </key>
     <key name="only-topbar" type="b">
-      <default>false</default>
+      <default>true</default>
       <summary>Only override top bar DateMenu</summary>
       <description>If true, only modify the GNOME top bar DateMenu label, leaving other panels/taskbars untouched.</description>
     </key>


### PR DESCRIPTION
## Summary
- Fix GNOME Shell 46 `child-added` stage signals (no actor-added error)
- Restore default clock on disable/uninstall
- Live seconds preview in preferences
- DD/MM + seconds preset (all timezones)
- **Supersedes v17.3.0 and earlier**

## Test plan
- [x] Extension ACTIVE v21 on GNOME 46
- [x] No actor-added error
- [x] Live preview ticks with seconds


Made with [Cursor](https://cursor.com)