### PR TITLE
chore: harden release validation and cleanup

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Attest release zip (Sigstore)
         continue-on-error: true
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: ${{ steps.meta.outputs.zip }}
           push-to-registry: false

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ Thumbs.db
 __pycache__/
 *.pyc
 node_modules/
+.release-build/
+.package-build/
 
 # Security: Never commit secrets or credentials
 *.env

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -52,11 +52,13 @@ pack_dir() {
 
 echo "Building ESM (GNOME 45–50) from: $ESM_DIR"
 esm_tmp=$(mktemp -d)
+trap 'rm -rf "$esm_tmp"' EXIT
 esm_zip=$(pack_dir "$ESM_DIR" "$esm_tmp" "$DIST_DIR")
 if command -v zip >/dev/null 2>&1; then
   zip -d "$esm_zip" 'schemas/gschemas.compiled' >/dev/null 2>&1 || true
 fi
 rm -rf "$esm_tmp"
+trap - EXIT
 
 echo
 echo "Done. Artifact:"

--- a/tools/validate.sh
+++ b/tools/validate.sh
@@ -27,33 +27,25 @@ meta_field() {
   unzip -p "$zip" metadata.json | tr -d '\r' | sed -n -E "s/^[[:space:]]*\"${key}\"[[:space:]]*:[[:space:]]*\"?([^\",}]+)\"?.*$/\1/p" | head -n1
 }
 
-pick_latest_esm_zip() {
-  local best_zip="" best_ver=0
-  for z in dist/numeric-clock@nickotmazgin.v*.shell-extension.zip; do
-    [[ -f "$z" ]] || continue
-    if zipinfo -1 "$z" | grep -qx 'schemas/gschemas.compiled'; then
-      continue
-    fi
-    local v
-    v=$(meta_field "$z" version)
-    [[ "$v" =~ ^[0-9]+$ ]] || continue
-    if (( v > best_ver )); then best_ver=$v; best_zip="$z"; fi
-  done
-  echo -n "$best_zip"
-}
-
 main() {
-  local esm_zip
-  esm_zip=$(pick_latest_esm_zip)
+  local expected_version expected_name esm_zip
+  expected_version=$(python3 -c 'import json; print(json.load(open("src/metadata.json"))["version"])')
+  expected_name=$(python3 -c 'import json; print(json.load(open("src/metadata.json"))["version-name"])')
+  esm_zip="dist/numeric-clock@nickotmazgin.v${expected_version}.shell-extension.zip"
 
   say "Checking ESM zip: ${esm_zip:-<none>}"
-  if [[ -n "$esm_zip" ]]; then
+  if [[ -f "$esm_zip" ]]; then
     check_zip_lacks "$esm_zip" schemas/gschemas.compiled
     check_zip_has   "$esm_zip" metadata.json
-    local v shellv
+    check_zip_has   "$esm_zip" schemas/org.gnome.shell.extensions.numeric-clock.gschema.xml
+    local v version_name shellv
     v=$(meta_field "$esm_zip" version)
-    shellv=$(unzip -p "$esm_zip" metadata.json | tr -d '\n' | sed -n -E 's/.*"shell-version"\s*:\s*\[([^\]]+)\].*/\1/p')
-    say "ESM version=$v shell-version=[$shellv]"
+    version_name=$(python3 -c 'import json,sys,zipfile; print(json.loads(zipfile.ZipFile(sys.argv[1]).read("metadata.json"))["version-name"])' "$esm_zip")
+    shellv=$(python3 -c 'import json,sys,zipfile; print(",".join(json.loads(zipfile.ZipFile(sys.argv[1]).read("metadata.json"))["shell-version"]))' "$esm_zip")
+    [[ "$v" = "$expected_version" ]] || { say "ERROR: version=$v, expected $expected_version"; fail=1; }
+    [[ "$version_name" = "$expected_name" ]] || { say "ERROR: version-name=$version_name, expected $expected_name"; fail=1; }
+    [[ "$shellv" = "45,46,47,48,49,50" ]] || { say "ERROR: shell-version=[$shellv]"; fail=1; }
+    say "ESM version=$v version-name=$version_name shell-version=[$shellv]"
   else
     say "ERROR: no ESM zip found"; fail=1
   fi


### PR DESCRIPTION
## Summary

- update release provenance from `actions/attest-build-provenance@v2` to `@v4`
- validate the exact versioned ZIP declared by `src/metadata.json`
- assert version, version-name, GNOME 45–50 compatibility, required schema, and absence of compiled schemas
- clean temporary build directories reliably on interruption
- ignore interrupted local package-build directories

## Local verification

- shell syntax, JSON, XML, and schema checks pass
- release ZIP builds successfully
- strict release validator passes for extension version 22 / v17.3.2
- generated ZIPs, Python caches, and obsolete local legacy residue were removed after testing
