### PR TITLE
docs: add credits, contributors, and AI-assistance attribution

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,24 @@
+# Contributors
+
+Thank you to everyone who has helped make Numeric Clock better.
+
+## Maintainer
+
+- **[Nick Otmazgin](https://github.com/nickotmazgin)** — creator, sole administrator, and solo developer: code author, reviewer, lead developer, release manager, and signer of all official releases
+
+## AI Development Assistants
+
+Recent releases were developed with help from AI pair-programming agents. As the project's sole admin and solo developer, Nick Otmazgin directs all AI-assisted work — writing and contributing code himself, reviewing every change, testing on real GNOME sessions, and personally approving, signing, and publishing each release. Final responsibility for every released line of code rests with the human maintainer.
+
+| Assistant | Role |
+|-----------|------|
+| **[OpenAI Codex](https://openai.com/codex/)** | Release engineering, signed-tag release workflows, release validation and CI hardening |
+| **[Cursor (Agent)](https://cursor.com)** | Code review, debugging, documentation |
+
+## Community
+
+- Bug reporters and testers via [GitHub Issues](https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock/issues)
+
+---
+
+*OpenAI and Codex are trademarks of OpenAI. Cursor is a trademark of Anysphere, Inc. Names are used for factual attribution only; this project is not affiliated with, sponsored, or endorsed by either company.*

--- a/README.md
+++ b/README.md
@@ -194,6 +194,24 @@ MIT © Nick Otmazgin — see [LICENSE](LICENSE).
 
 ---
 
+## Credits & Acknowledgements
+
+Numeric Clock is created, maintained, signed, and released by **[Nick Otmazgin](https://github.com/nickotmazgin)** — the project's sole administrator and solo developer, who authors and reviews all code that ships.
+
+[![AI assisted — OpenAI Codex](https://img.shields.io/badge/AI%20assisted-OpenAI%20Codex-10A37F)](https://openai.com/codex/)
+[![AI assisted — Cursor Agent](https://img.shields.io/badge/AI%20assisted-Cursor%20Agent-1A1A1A)](https://cursor.com)
+
+Recent releases were built with help from AI pair-programming agents, operated under the maintainer's direction and review:
+
+- **OpenAI Codex** — release engineering, signed-tag release workflows, release validation and CI hardening
+- **Cursor (Agent)** — code review, debugging, documentation
+
+Every AI-assisted change is human-reviewed, tested on real GNOME sessions, and approved by the maintainer before release. See [CONTRIBUTORS.md](CONTRIBUTORS.md) for the full credits.
+
+> OpenAI and Codex are trademarks of OpenAI. Cursor is a trademark of Anysphere, Inc. These names are used here solely for factual attribution. Numeric Clock is an independent project and is **not** affiliated with, sponsored, or endorsed by OpenAI or Anysphere/Cursor.
+
+---
+
 ## Find this project
 
 **GitHub topics:** `gnome-shell-extension` · `clock` · `24-hour` · `numeric-date` · `top-bar` · `seconds` · `wayland` · `linux` · `open-source`


### PR DESCRIPTION
## Summary
- Add CONTRIBUTORS.md naming Nick Otmazgin as sole administrator and solo developer (author, reviewer, release manager, signer) and crediting AI pair-programming assistants (OpenAI Codex, Cursor Agent) with trademark disclaimers.
- Add matching "Credits & Acknowledgements" section to README.

Docs-only change.

Made with [Cursor](https://cursor.com)