### PR TITLE
release: v17.3.3 — hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v17.3.3 — 2026-06-11
+
+**Security and packaging hardening.**
+
+- Cap format-string length in preferences (128 characters)
+- Release validation asserts `extension.js` and `prefs.js` are present in the zip
+- `only-topbar` remains default `true` (safest; disabling can affect other panel clocks)
+
+> **Recommended upgrade** from v17.3.2 and earlier.
+
 ## End of GNOME Shell 42–44 support — 2026-06-02
 
 **Numeric Clock no longer builds, tests, or maintains a GNOME Shell 42–44 package.**

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 
 A lightweight GNOME Shell extension that replaces the top-bar clock with a **numeric, fully configurable** format — ideal for **DD/MM/YYYY** and **24-hour** time with optional **seconds**.
 
-**Latest:** v17.3.2 — ESM build v22 for **GNOME 45–50** (Shell 46 tested on Zorin OS 18.1)
+**Latest:** v17.3.3 — ESM build v23 for **GNOME 45–50** (Shell 46 tested on Zorin OS 18.1)
 
-> Download only [v17.3.2](https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock/releases/latest).
+> Download only [v17.3.3](https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock/releases/latest). Older releases are kept for history.
 
 **UUID:** `numeric-clock@nickotmazgin`
 

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -10,8 +10,8 @@
     "49",
     "50"
   ],
-  "version": 22,
-  "version-name": "17.3.2 45.50",
+  "version": 23,
+  "version-name": "17.3.3 45.50",
   "settings-schema": "org.gnome.shell.extensions.numeric-clock",
   "gettext-domain": "numeric-clock",
   "url": "https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock",

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -28,7 +28,12 @@ export default class NumericClockPrefs extends ExtensionPreferences {
     const rowFmt = new Adw.ActionRow({ title: _('Format string') });
     const entry = new Gtk.Entry({ hexpand: true, placeholder_text: '%d/%m/%Y %H:%M:%S' });
     entry.text = settings.get_string('format-string');
-    entry.connect('changed', w => settings.set_string('format-string', w.text));
+    entry.connect('changed', w => {
+      const text = String(w.text || '').slice(0, 128);
+      if (text !== w.text)
+        w.text = text;
+      settings.set_string('format-string', text);
+    });
     rowFmt.add_suffix(entry);
     rowFmt.activatable_widget = entry;
     group.add(rowFmt);

--- a/tools/validate.sh
+++ b/tools/validate.sh
@@ -37,7 +37,11 @@ main() {
   if [[ -f "$esm_zip" ]]; then
     check_zip_lacks "$esm_zip" schemas/gschemas.compiled
     check_zip_has   "$esm_zip" metadata.json
+    check_zip_has   "$esm_zip" extension.js
+    check_zip_has   "$esm_zip" prefs.js
     check_zip_has   "$esm_zip" schemas/org.gnome.shell.extensions.numeric-clock.gschema.xml
+    check_zip_lacks "$esm_zip" tools/build.sh
+    check_zip_lacks "$esm_zip" .env
     local v version_name shellv
     v=$(meta_field "$esm_zip" version)
     version_name=$(python3 -c 'import json,sys,zipfile; print(json.loads(zipfile.ZipFile(sys.argv[1]).read("metadata.json"))["version-name"])' "$esm_zip")


### PR DESCRIPTION
## Summary
- Cap format-string length, strengthen release zip validation

## Test plan
- [x] tools/validate.sh passes after build


Made with [Cursor](https://cursor.com)