### PR TITLE
release: v17.4.0 — panel access icon and quick controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v17.4.0 — 2026-06-11
+
+**Panel access icon and quick controls.**
+
+- Add a **top-bar clock icon** (`numeric-clock-symbolic`) for fast access to preferences, format presets, and copy-current-time
+- New **Show panel access icon** preference (on by default; hide if you only want the formatted clock text)
+- Fix `shellMajor()` to use the GNOME 45+ `Config` module instead of legacy `imports`
+- Preferences reset now updates all toggle switches correctly
+- README and install docs aligned to extension build **v24**
+
+> **Recommended upgrade** from v17.3.3 and earlier.
+
 ## v17.3.3 — 2026-06-11
 
 **Security and packaging hardening.**

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 
 A lightweight GNOME Shell extension that replaces the top-bar clock with a **numeric, fully configurable** format — ideal for **DD/MM/YYYY** and **24-hour** time with optional **seconds**.
 
-**Latest:** v17.3.3 — ESM build v23 for **GNOME 45–50** (Shell 46 tested on Zorin OS 18.1)
+**Latest:** v17.4.0 — ESM build v24 for **GNOME 45–50** (Shell 46 tested on Zorin OS 18.1)
 
-> Download only [v17.3.3](https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock/releases/latest). Older releases are kept for history.
+> Download only [v17.4.0](https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock/releases/latest). Older releases are kept for history and marked superseded.
 
 **UUID:** `numeric-clock@nickotmazgin`
 
@@ -49,6 +49,7 @@ A lightweight GNOME Shell extension that replaces the top-bar clock with a **num
 * Configurable **update interval** (1–300 seconds)
 * **Smooth second tick** alignment when showing seconds
 * Presets: Default, Seconds (with weekday), **DD/MM + seconds** (any timezone)
+* **Panel access icon** — clock icon in the top bar opens a quick menu (preferences, presets, copy time)
 * **Restore default clock** when disabled or uninstalled
 * Safe plain-text rendering (no Pango markup)
 * No network access, telemetry, or external services
@@ -59,7 +60,7 @@ A lightweight GNOME Shell extension that replaces the top-bar clock with a **num
 
 | GNOME | Status | Extension version | Notes |
 | ----- | ------ | ----------------: | ----- |
-| **45–50** | **Supported** | 22 | ESM build; do not ship `schemas/gschemas.compiled` |
+| **45–50** | **Supported** | 24 | ESM build; do not ship `schemas/gschemas.compiled` |
 | **42–44** | **Discontinued** | — | No longer built or maintained |
 
 **Minimum requirement:** GNOME Shell **45**.
@@ -71,7 +72,7 @@ A lightweight GNOME Shell extension that replaces the top-bar clock with a **num
 ### From GitHub release (recommended)
 
 ```bash
-gnome-extensions install --force dist/numeric-clock@nickotmazgin.v22.shell-extension.zip
+gnome-extensions install --force dist/numeric-clock@nickotmazgin.v24.shell-extension.zip
 gnome-extensions enable numeric-clock@nickotmazgin
 gnome-extensions prefs numeric-clock@nickotmazgin
 ```
@@ -81,7 +82,7 @@ gnome-extensions prefs numeric-clock@nickotmazgin
 ```bash
 ./tools/build.sh
 ./tools/validate.sh
-gnome-extensions install --force dist/numeric-clock@nickotmazgin.v22.shell-extension.zip
+gnome-extensions install --force dist/numeric-clock@nickotmazgin.v24.shell-extension.zip
 gnome-extensions enable numeric-clock@nickotmazgin
 ```
 
@@ -98,8 +99,11 @@ Open **Preferences** and set:
 * **Format string** — any `strftime` pattern
 * **Update interval (seconds)** — use `1` when showing seconds
 * **Smooth tick** — align updates to second boundaries
+* **Show panel access icon** — top-bar clock icon for quick menu access
 
 Changes apply immediately as you type.
+
+Click the **clock icon** in the top bar (next to the system tray) for **Open Preferences**, **Copy current time**, and **Quick presets** without opening the full settings window.
 
 ### Israel setup (example)
 
@@ -159,7 +163,7 @@ journalctl --user -b 0 -o cat | grep -i numeric-clock
 ## Packaging & releases (maintainers)
 
 ```bash
-./tools/build.sh    # -> dist/numeric-clock@nickotmazgin.v22.shell-extension.zip (GNOME 45–50)
+./tools/build.sh    # -> dist/numeric-clock@nickotmazgin.v24.shell-extension.zip (GNOME 45–50)
 ./tools/validate.sh
 ```
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -2,8 +2,12 @@
 // Numeric Clock — GNOME 45+ (ESM)
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
 import St from 'gi://St';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 const HOOKED = Symbol('nc-hooked');
@@ -37,7 +41,6 @@ function allStageLabels() {
 
 function shellMajor() {
   try {
-    const Config = imports.misc.config;
     const ver = Config.PACKAGE_VERSION || '';
     const major = parseInt(String(ver).split('.')[0], 10);
     if (Number.isFinite(major) && major > 0)
@@ -65,10 +68,127 @@ function disconnectStageSignal(stage, id) {
   try { stage.disconnect(id); } catch {}
 }
 
+function copyTextToClipboard(text) {
+  try {
+    St.Clipboard.get_default().set_text(St.ClipboardType.CLIPBOARD, String(text || ''));
+    Main.notify('Numeric Clock', 'Time copied to clipboard');
+  } catch (e) {
+    console.error('[Numeric Clock] clipboard error:', e);
+  }
+}
+
+const NumericClockIndicator = GObject.registerClass(
+class NumericClockIndicator extends PanelMenu.Button {
+  _init(settings, extensionPath, openPrefs) {
+    super._init(0.0, 'Numeric Clock');
+    this._settings = settings;
+    this._openPrefs = openPrefs;
+    this._timeLabel = null;
+    this._menuTimerId = 0;
+
+    const iconPath = GLib.build_filenamev([extensionPath, 'icons', 'numeric-clock-symbolic.svg']);
+    const icon = new St.Icon({
+      gicon: Gio.Icon.new_for_string(iconPath),
+      style_class: 'system-status-icon numeric-clock-icon',
+    });
+    this.add_child(icon);
+    this._buildMenu();
+
+    this._settingsChangedIds = [
+      this._settings.connect('changed::format-string', () => this._refreshMenuTime()),
+      this._settings.connect('changed::show-panel-icon', () => this._syncVisibility()),
+    ];
+    this._syncVisibility();
+  }
+
+  destroy() {
+    this._clearMenuTimer();
+    for (const id of this._settingsChangedIds || []) {
+      try { this._settings.disconnect(id); } catch {}
+    }
+    this._settingsChangedIds = [];
+    super.destroy();
+  }
+
+  _syncVisibility() {
+    const show = this._settings.get_boolean('show-panel-icon');
+    this.visible = show;
+  }
+
+  _clearMenuTimer() {
+    if (this._menuTimerId) {
+      GLib.source_remove(this._menuTimerId);
+      this._menuTimerId = 0;
+    }
+  }
+
+  _refreshMenuTime() {
+    if (!this._timeLabel?.label) return;
+    this._timeLabel.label.text = formatNow(this._settings.get_string('format-string'));
+  }
+
+  _startMenuTimer() {
+    this._clearMenuTimer();
+    this._refreshMenuTime();
+    this._menuTimerId = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 1, () => {
+      this._refreshMenuTime();
+      return GLib.SOURCE_CONTINUE;
+    });
+  }
+
+  _applyPreset(fmt, interval, smooth, onlyTopbar) {
+    this._settings.set_string('format-string', fmt);
+    this._settings.set_int('update-interval', interval);
+    this._settings.set_boolean('smooth-second', smooth);
+    if (onlyTopbar !== undefined)
+      this._settings.set_boolean('only-topbar', onlyTopbar);
+    this._refreshMenuTime();
+    Main.notify('Numeric Clock', 'Format preset applied');
+  }
+
+  _buildMenu() {
+    this.menu.removeAll();
+    this._timeLabel = new PopupMenu.PopupMenuItem('', { reactive: false, can_focus: false });
+    this._timeLabel.label.clutter_text.ellipsize = 3;
+    this.menu.addMenuItem(this._timeLabel);
+
+    this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
+    const prefsItem = new PopupMenu.PopupMenuItem('Open Preferences');
+    prefsItem.connect('activate', () => this._openPrefs());
+    this.menu.addMenuItem(prefsItem);
+
+    const copyItem = new PopupMenu.PopupMenuItem('Copy current time');
+    copyItem.connect('activate', () => {
+      copyTextToClipboard(formatNow(this._settings.get_string('format-string')));
+    });
+    this.menu.addMenuItem(copyItem);
+
+    const presets = new PopupMenu.PopupSubMenuMenuItem('Quick presets');
+    const addPreset = (label, fmt, interval, smooth, onlyTopbar) => {
+      const item = new PopupMenu.PopupMenuItem(label);
+      item.connect('activate', () => this._applyPreset(fmt, interval, smooth, onlyTopbar));
+      presets.menu.addMenuItem(item);
+    };
+    addPreset('Default (DD/MM/YYYY + seconds)', '%d/%m/%Y %H:%M:%S', 1, true);
+    addPreset('Weekday + seconds', '%A %d/%m/%Y %H:%M:%S', 1, true);
+    addPreset('Top bar only (DD/MM + seconds)', '%d/%m/%Y %H:%M:%S', 1, true, true);
+    this.menu.addMenuItem(presets);
+
+    this.menu.connect('open-state-changed', (_menu, open) => {
+      if (open)
+        this._startMenuTimer();
+      else
+        this._clearMenuTimer();
+    });
+  }
+});
+
 export default class NumericClockExtension extends Extension {
   constructor(uuid) {
     super(uuid);
     this._settings = null;
+    this._indicator = null;
     this._timeoutId = 0;
     this._msTimeoutId = 0;
     this._stageAddedId = 0;
@@ -162,19 +282,41 @@ export default class NumericClockExtension extends Extension {
     }
   }
 
+  _syncIndicator() {
+    if (!this._indicator) return;
+    const show = this._settings.get_boolean('show-panel-icon');
+    this._indicator.visible = show;
+  }
+
   enable() {
     this._settings = this.getSettings();
+
+    this._indicator = new NumericClockIndicator(
+      this._settings,
+      this.path,
+      () => this.openPreferences(),
+    );
+    Main.panel.addToStatusArea('numeric-clock-access', this._indicator, 1, 'right');
 
     this._settingsChangedIds.push(
       this._settings.connect('changed::format-string', () => this._updateAllNow()),
       this._settings.connect('changed::update-interval', () => this._restartTimer()),
+      this._settings.connect('changed::smooth-second', () => this._restartTimer()),
+      this._settings.connect('changed::only-topbar', () => this._updateAllNow()),
+      this._settings.connect('changed::show-panel-icon', () => this._syncIndicator()),
     );
     this._stageAddedId = connectStageSignal(global.stage, 'added', () => this._updateAllNow());
     this._stageRemovedId = connectStageSignal(global.stage, 'removed', () => this._updateAllNow());
     this._restartTimer();
+    this._syncIndicator();
   }
 
   disable() {
+    if (this._indicator) {
+      this._indicator.destroy();
+      this._indicator = null;
+    }
+
     if (this._timeoutId) GLib.source_remove(this._timeoutId);
     this._timeoutId = 0;
     if (this._msTimeoutId) GLib.source_remove(this._msTimeoutId);

--- a/src/icons/numeric-clock-symbolic.svg
+++ b/src/icons/numeric-clock-symbolic.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M8 1.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13Zm0 1a5.5 5.5 0 1 1 0 11 5.5 5.5 0 0 1 0-11Z"/>
+  <path fill="currentColor" d="M8 3.25a.75.75 0 0 0-.75.75v3.9c0 .2.08.39.22.53l2.2 2.2a.75.75 0 1 0 1.06-1.06L8.75 7.56V4a.75.75 0 0 0-.75-.75Z"/>
+  <path fill="currentColor" d="M4.1 11.35a.55.55 0 0 0-.08.78l.35.35h7.26l.35-.35a.55.55 0 0 0-.78-.78l-.22.22H4.9l-.22-.22Z"/>
+  <path fill="currentColor" d="M5.15 9.55h.9v.7h-.9v-.7Zm1.35 0h.9v.7h-.9v-.7Zm1.35 0h.9v.7h-.9v-.7Zm1.35 0h.9v.7h-.9v-.7Z"/>
+</svg>

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -10,8 +10,9 @@
     "49",
     "50"
   ],
-  "version": 23,
-  "version-name": "17.3.3 45.50",
+  "version": 24,
+  "version-name": "17.4.0 45.50",
+  "icon": "numeric-clock-symbolic",
   "settings-schema": "org.gnome.shell.extensions.numeric-clock",
   "gettext-domain": "numeric-clock",
   "url": "https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock",

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -94,6 +94,16 @@ export default class NumericClockPrefs extends ExtensionPreferences {
     rowSmooth.activatable_widget = swSmooth;
     group.add(rowSmooth);
 
+    const rowIcon = new Adw.ActionRow({
+      title: _('Show panel access icon'),
+      subtitle: _('Clock icon in the top bar — click for preferences, presets, and copy time'),
+    });
+    const swIcon = new Gtk.Switch({ active: settings.get_boolean('show-panel-icon') });
+    swIcon.connect('notify::active', w => settings.set_boolean('show-panel-icon', w.active));
+    rowIcon.add_suffix(swIcon);
+    rowIcon.activatable_widget = swIcon;
+    group.add(rowIcon);
+
     const rowPresets = new Adw.ActionRow({
       title: _('Presets'),
       subtitle: _('Quick formats for any timezone — uses your system clock (e.g. Asia/Jerusalem)'),
@@ -130,9 +140,13 @@ export default class NumericClockPrefs extends ExtensionPreferences {
         settings.reset('update-interval');
         settings.reset('smooth-second');
         settings.reset('only-topbar');
+        settings.reset('show-panel-icon');
         entry.text = settings.get_string('format-string');
         if (typeof spin.set_value === 'function')
           spin.set_value(settings.get_int('update-interval'));
+        swOnly.active = settings.get_boolean('only-topbar');
+        swSmooth.active = settings.get_boolean('smooth-second');
+        swIcon.active = settings.get_boolean('show-panel-icon');
         refreshPreview();
       } catch (_) {}
     });

--- a/src/schemas/org.gnome.shell.extensions.numeric-clock.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.numeric-clock.gschema.xml
@@ -22,5 +22,10 @@
       <summary>Smooth tick alignment</summary>
       <description>Align the first update to the next second boundary when the interval is 1s.</description>
     </key>
+    <key name="show-panel-icon" type="b">
+      <default>true</default>
+      <summary>Show panel access icon</summary>
+      <description>Display a clock icon in the top bar for quick preferences, presets, and copy-time access.</description>
+    </key>
   </schema>
 </schemalist>

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -44,6 +44,10 @@ pack_dir() {
     (cd "$tmpdir" && zip -qr "$basezip" .)
   fi
 
+  if [[ -d "$tmpdir/icons" ]] && command -v zip >/dev/null 2>&1; then
+    (cd "$tmpdir" && zip -qr "$basezip" icons/)
+  fi
+
   local dest="$dist/${uuid}.v${version}.shell-extension.zip"
   rm -f "$dest"
   mv -f "$basezip" "$dest"

--- a/tools/validate.sh
+++ b/tools/validate.sh
@@ -39,6 +39,7 @@ main() {
     check_zip_has   "$esm_zip" metadata.json
     check_zip_has   "$esm_zip" extension.js
     check_zip_has   "$esm_zip" prefs.js
+    check_zip_has   "$esm_zip" icons/numeric-clock-symbolic.svg
     check_zip_has   "$esm_zip" schemas/org.gnome.shell.extensions.numeric-clock.gschema.xml
     check_zip_lacks "$esm_zip" tools/build.sh
     check_zip_lacks "$esm_zip" .env


### PR DESCRIPTION
## Summary
- Add a **top-bar clock icon** (`numeric-clock-symbolic`) with quick menu: preferences, copy time, format presets
- New **Show panel access icon** preference (default on)
- Fix GNOME 45+ `Config` import (replaces legacy `imports.misc.config`)
- Fix preferences reset syncing all toggle switches
- README/CHANGELOG aligned to build v24; validate checks icon in zip; build packs `icons/`

## Test plan
- [x] `./tools/build.sh` && `./tools/validate.sh` pass locally
- [ ] Install zip, reload Shell, confirm clock icon appears and menu works
- [ ] Confirm formatted top-bar clock still updates correctly


Made with [Cursor](https://cursor.com)