### PR TITLE
chore: fix release-publish workflow startup_failure

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -3,7 +3,8 @@ name: Release Publish
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -58,7 +59,7 @@ jobs:
 
       - name: Attest release zip (Sigstore)
         continue-on-error: true
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: ${{ steps.meta.outputs.zip }}
           push-to-registry: false


### PR DESCRIPTION
## Summary
- Broaden tag filter to `v*` (same as EaseHub/ClipFlow pattern)
- Add `workflow_dispatch` for manual retries
- Use `actions/attest-build-provenance@v4` instead of pinned SHA

Fixes repeated `startup_failure` on tag push for Numeric Clock releases.

## Test plan
- [ ] Merge and run workflow_dispatch against latest tag


Made with [Cursor](https://cursor.com)