### PR TITLE
release: v17.4.1 — international polish, digital icon, quick access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v17.4.1 — 2026-06-11
+
+**International polish, refined icon, and easier access.**
+
+- Redesign panel icon to a cleaner **digital display** style (readable at 16px)
+- Add **7 international format presets** (ISO, compact, time-only, US 12-hour, and more) via shared `presets.js`
+- **Tooltip** on panel icon; **right-click / middle-click** the formatted clock for the quick menu (left-click keeps GNOME calendar)
+- Documentation reframed for **worldwide** use — system locale/timezone, not region-specific
+- Menu items include symbolic icons; `only-topbar` preference shows a safety note
+
+> **Recommended upgrade** from v17.4.0 and earlier.
+
 ## v17.4.0 — 2026-06-11
 
 **Panel access icon and quick controls.**

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,28 @@
+# Privacy Policy — Numeric Clock
+
+Numeric Clock is a local GNOME Shell extension. It does not collect, transmit, or sell personal data.
+
+## What stays on your computer
+
+- Your chosen **format string** and extension preferences (stored via GSettings on your system)
+- The extension reads your **system clock, locale, and timezone** only to display the time
+
+## What Numeric Clock does not do
+
+- No network access, analytics, telemetry, or crash reporting
+- No accounts, sign-in, or cloud sync
+- No access to files, contacts, location services, or other applications beyond the GNOME top-bar clock labels it formats
+
+## Third parties
+
+This extension does not embed third-party trackers or advertising SDKs. Links in the About page (GitHub, PayPal donate) open only when you click them.
+
+## GNOME and your distribution
+
+Numeric Clock runs inside GNOME Shell under your user session. It follows the same local-only model as other official-style panel extensions. Your Linux distribution (e.g. Zorin OS, Ubuntu) and GNOME project policies govern the desktop environment itself.
+
+## Contact
+
+Privacy questions: [nickotmazgin.dev@gmail.com](mailto:nickotmazgin.dev@gmail.com) or [GitHub Security](https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock/security).
+
+MIT License — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@
 [![i18n](https://img.shields.io/badge/i18n-gettext-blue)](#features)
 [![PayPal](https://img.shields.io/badge/Donate-PayPal-0070BA?logo=paypal&logoColor=white)](https://www.paypal.com/donate/?hosted_button_id=4HM44VH47LSMW)
 
-A lightweight GNOME Shell extension that replaces the top-bar clock with a **numeric, fully configurable** format — ideal for **DD/MM/YYYY** and **24-hour** time with optional **seconds**.
+A lightweight GNOME Shell extension that replaces the top-bar clock with a **numeric, fully configurable** format — ideal for **DD/MM/YYYY**, **ISO 8601**, **24-hour**, or **12-hour** time with optional **seconds**, anywhere in the world.
 
-**Latest:** v17.4.0 — ESM build v24 for **GNOME 45–50** (Shell 46 tested on Zorin OS 18.1)
+**Latest:** v17.4.1 — ESM build v25 for **GNOME 45–50** (Shell 46 tested on Zorin OS 18.1)
 
-> Download only [v17.4.0](https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock/releases/latest). Older releases are kept for history and marked superseded.
+> Download only [v17.4.1](https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock/releases/latest). Older releases are kept for history and marked superseded.
 
 **UUID:** `numeric-clock@nickotmazgin`
 
-> **Keywords:** GNOME clock · numeric date · DD/MM/YYYY · 24-hour time · seconds · top bar · Israel timezone · Linux desktop · open source
+> **Keywords:** GNOME clock · numeric date · DD/MM/YYYY · ISO 8601 · 24-hour time · international · top bar · Linux desktop · open source
 
 > **GNOME Shell 42–44 is no longer supported.** Numeric Clock requires **GNOME 45–50**.
 
@@ -30,6 +30,8 @@ A lightweight GNOME Shell extension that replaces the top-bar clock with a **num
 ## Quick links
 
 * **Latest release (ZIPs):** [GitHub Releases](https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock/releases/latest)
+* **Privacy:** [PRIVACY.md](PRIVACY.md)
+* **Security:** [SECURITY.md](SECURITY.md)
 * **Issues:** [Report a bug](https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock/issues)
 * **Discussions:** [Ask a question](https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock/discussions)
 
@@ -44,15 +46,16 @@ A lightweight GNOME Shell extension that replaces the top-bar clock with a **num
 ## Features
 
 * Fully numeric date/time — you choose the `strftime` **format string**
-* **Israel-friendly defaults:** `DD/MM/YYYY HH:MM:SS` (24-hour, seconds, system timezone e.g. `Asia/Jerusalem`)
+* **International defaults:** `DD/MM/YYYY HH:MM:SS` (24-hour, seconds; uses your **system locale and timezone**)
+* **7 format presets:** International, weekday, compact, time-only, ISO 8601, US 12-hour, top-bar only
 * **Live preview** in settings — ticks every second when format shows seconds
 * Configurable **update interval** (1–300 seconds)
 * **Smooth second tick** alignment when showing seconds
-* Presets: Default, Seconds (with weekday), **DD/MM + seconds** (any timezone)
-* **Panel access icon** — clock icon in the top bar opens a quick menu (preferences, presets, copy time)
+* **Panel access icon** — digital clock icon opens a quick menu (preferences, presets, copy time)
+* **Right-click the formatted clock** for the same quick menu (left-click still opens GNOME calendar)
 * **Restore default clock** when disabled or uninstalled
 * Safe plain-text rendering (no Pango markup)
-* No network access, telemetry, or external services
+* No network access, telemetry, or external services — see [PRIVACY.md](PRIVACY.md)
 
 ---
 
@@ -60,10 +63,12 @@ A lightweight GNOME Shell extension that replaces the top-bar clock with a **num
 
 | GNOME | Status | Extension version | Notes |
 | ----- | ------ | ----------------: | ----- |
-| **45–50** | **Supported** | 24 | ESM build; do not ship `schemas/gschemas.compiled` |
+| **45–50** | **Supported** | 25 | ESM build; do not ship `schemas/gschemas.compiled` |
 | **42–44** | **Discontinued** | — | No longer built or maintained |
 
 **Minimum requirement:** GNOME Shell **45**.
+
+Works on **Zorin OS**, Ubuntu, Fedora, and other GNOME-based distributions that ship Shell 45–50.
 
 ---
 
@@ -72,7 +77,7 @@ A lightweight GNOME Shell extension that replaces the top-bar clock with a **num
 ### From GitHub release (recommended)
 
 ```bash
-gnome-extensions install --force dist/numeric-clock@nickotmazgin.v24.shell-extension.zip
+gnome-extensions install --force dist/numeric-clock@nickotmazgin.v25.shell-extension.zip
 gnome-extensions enable numeric-clock@nickotmazgin
 gnome-extensions prefs numeric-clock@nickotmazgin
 ```
@@ -82,7 +87,7 @@ gnome-extensions prefs numeric-clock@nickotmazgin
 ```bash
 ./tools/build.sh
 ./tools/validate.sh
-gnome-extensions install --force dist/numeric-clock@nickotmazgin.v24.shell-extension.zip
+gnome-extensions install --force dist/numeric-clock@nickotmazgin.v25.shell-extension.zip
 gnome-extensions enable numeric-clock@nickotmazgin
 ```
 
@@ -99,34 +104,50 @@ Open **Preferences** and set:
 * **Format string** — any `strftime` pattern
 * **Update interval (seconds)** — use `1` when showing seconds
 * **Smooth tick** — align updates to second boundaries
-* **Show panel access icon** — top-bar clock icon for quick menu access
+* **Show panel access icon** — digital clock icon for quick menu
+* **Right-click clock for quick menu** — secondary/middle click on the formatted clock
 
 Changes apply immediately as you type.
 
-Click the **clock icon** in the top bar (next to the system tray) for **Open Preferences**, **Copy current time**, and **Quick presets** without opening the full settings window.
+**Quick access:**
 
-### Israel setup (example)
+* Click the **panel clock icon** (system tray area) for preferences, presets, and copy time
+* **Right-click** or **middle-click** the formatted top-bar clock for the same menu
+* **Left-click** the clock still opens the standard GNOME calendar
 
-Set your system timezone to `Asia/Jerusalem`, then use the **Israel** preset or:
+### Regional examples
+
+Numeric Clock uses your **system timezone** — set it in OS Settings. Examples:
+
+**Europe / DD/MM (24-hour):**
 
 ```bash
 gsettings set org.gnome.shell.extensions.numeric-clock format-string '%d/%m/%Y %H:%M:%S'
-gsettings set org.gnome.shell.extensions.numeric-clock update-interval 1
-gsettings set org.gnome.shell.extensions.numeric-clock smooth-second true
-gsettings set org.gnome.shell.extensions.numeric-clock only-topbar true
 ```
 
-Example output: `30/05/2026 18:20:06`
+**ISO 8601 (worldwide standard):**
+
+```bash
+gsettings set org.gnome.shell.extensions.numeric-clock format-string '%Y-%m-%d %H:%M:%S'
+```
+
+**US (12-hour):**
+
+```bash
+gsettings set org.gnome.shell.extensions.numeric-clock format-string '%m/%d/%Y %I:%M:%S %p'
+```
+
+Or use the matching **preset buttons** in Preferences.
 
 ### Quick `strftime` cheatsheet
 
-`%A` weekday · `%a` short weekday · `%d` day · `%m` month · `%Y` year · `%H` hour (00–23) · `%M` minute · `%S` second
+`%A` weekday · `%a` short weekday · `%d` day · `%m` month · `%Y` year · `%H` hour (00–23) · `%I` hour (01–12) · `%p` AM/PM · `%M` minute · `%S` second
 
 Examples:
 
 * `%d/%m/%Y %H:%M:%S` → `30/05/2026 18:20:06`
-* `%A %d/%m/%Y %H:%M:%S` → `Saturday 30/05/2026 18:20:06`
 * `%Y-%m-%d %H:%M:%S` → `2026-05-30 18:20:06`
+* `%m/%d/%Y %I:%M:%S %p` → `05/30/2026 06:20:06 PM`
 
 ---
 
@@ -163,19 +184,23 @@ journalctl --user -b 0 -o cat | grep -i numeric-clock
 ## Packaging & releases (maintainers)
 
 ```bash
-./tools/build.sh    # -> dist/numeric-clock@nickotmazgin.v24.shell-extension.zip (GNOME 45–50)
+./tools/build.sh    # -> dist/numeric-clock@nickotmazgin.v25.shell-extension.zip (GNOME 45–50)
 ./tools/validate.sh
 ```
 
-Tag `v*.*.*` to trigger CI upload of ZIPs to GitHub Releases.
+Tag `v*` to trigger CI upload of ZIPs to GitHub Releases.
 
 Do **not** commit `schemas/gschemas.compiled` to the repo.
 
 ---
 
-## Privacy
+## Privacy & compliance
 
-No network access. Only local preferences are stored.
+* **Privacy:** [PRIVACY.md](PRIVACY.md) — local-only, no network, no telemetry
+* **Security:** [SECURITY.md](SECURITY.md) — coordinated disclosure
+* **License:** MIT — see [LICENSE](LICENSE)
+
+This extension modifies only the top-bar clock display via supported GNOME Shell APIs. It does not bypass security, escalate privileges, or access data outside your session.
 
 ---
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Numeric Clock — GNOME 45+ (ESM)
+import Clutter from 'gi://Clutter';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
@@ -9,11 +10,14 @@ import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+import { FORMAT_PRESETS, applyPresetToSettings } from './presets.js';
 
 const HOOKED = Symbol('nc-hooked');
+const CLICK_HOOKED = Symbol('nc-click-hooked');
 const TIME_RE = /(^|\s)\d{1,2}:\d{2}(:\d{2})?(\s|$)/i;
 const MONTHS = /\b(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\b/i;
 const DAYS   = /\b(sun|mon|tue|wed|thu|fri|sat)\b/i;
+const PANEL_TOOLTIP = 'Numeric Clock — click for quick menu';
 
 function formatNow(fmt) {
   const dt = GLib.DateTime.new_now_local();
@@ -49,7 +53,6 @@ function shellMajor() {
   return 46;
 }
 
-/** GNOME 45+ MetaStage uses child-*; older shells use actor-*. Never connect actor-* on 45+. */
 function connectStageSignal(stage, addedOrRemoved, callback) {
   if (!stage || typeof stage.connect !== 'function')
     return 0;
@@ -77,6 +80,17 @@ function copyTextToClipboard(text) {
   }
 }
 
+function menuItemWithIcon(label, iconName) {
+  const item = new PopupMenu.PopupMenuItem(label);
+  if (iconName) {
+    item.insert_child_at_index(
+      new St.Icon({ icon_name: iconName, style_class: 'popup-menu-icon' }),
+      0,
+    );
+  }
+  return item;
+}
+
 const NumericClockIndicator = GObject.registerClass(
 class NumericClockIndicator extends PanelMenu.Button {
   _init(settings, extensionPath, openPrefs) {
@@ -92,6 +106,8 @@ class NumericClockIndicator extends PanelMenu.Button {
       style_class: 'system-status-icon numeric-clock-icon',
     });
     this.add_child(icon);
+    if (typeof this.set_tooltip_text === 'function')
+      this.set_tooltip_text(PANEL_TOOLTIP);
     this._buildMenu();
 
     this._settingsChangedIds = [
@@ -136,14 +152,8 @@ class NumericClockIndicator extends PanelMenu.Button {
     });
   }
 
-  _applyPreset(fmt, interval, smooth, onlyTopbar) {
-    this._settings.set_string('format-string', fmt);
-    this._settings.set_int('update-interval', interval);
-    this._settings.set_boolean('smooth-second', smooth);
-    if (onlyTopbar !== undefined)
-      this._settings.set_boolean('only-topbar', onlyTopbar);
-    this._refreshMenuTime();
-    Main.notify('Numeric Clock', 'Format preset applied');
+  openQuickMenu() {
+    this.menu.open();
   }
 
   _buildMenu() {
@@ -154,25 +164,27 @@ class NumericClockIndicator extends PanelMenu.Button {
 
     this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-    const prefsItem = new PopupMenu.PopupMenuItem('Open Preferences');
+    const prefsItem = menuItemWithIcon('Open Preferences', 'preferences-system-symbolic');
     prefsItem.connect('activate', () => this._openPrefs());
     this.menu.addMenuItem(prefsItem);
 
-    const copyItem = new PopupMenu.PopupMenuItem('Copy current time');
+    const copyItem = menuItemWithIcon('Copy current time', 'edit-copy-symbolic');
     copyItem.connect('activate', () => {
       copyTextToClipboard(formatNow(this._settings.get_string('format-string')));
     });
     this.menu.addMenuItem(copyItem);
 
     const presets = new PopupMenu.PopupSubMenuMenuItem('Quick presets');
-    const addPreset = (label, fmt, interval, smooth, onlyTopbar) => {
-      const item = new PopupMenu.PopupMenuItem(label);
-      item.connect('activate', () => this._applyPreset(fmt, interval, smooth, onlyTopbar));
+    presets.icon.icon_name = 'document-edit-symbolic';
+    for (const preset of FORMAT_PRESETS) {
+      const item = new PopupMenu.PopupMenuItem(preset.label);
+      item.connect('activate', () => {
+        applyPresetToSettings(this._settings, preset);
+        this._refreshMenuTime();
+        Main.notify('Numeric Clock', 'Format preset applied');
+      });
       presets.menu.addMenuItem(item);
-    };
-    addPreset('Default (DD/MM/YYYY + seconds)', '%d/%m/%Y %H:%M:%S', 1, true);
-    addPreset('Weekday + seconds', '%A %d/%m/%Y %H:%M:%S', 1, true);
-    addPreset('Top bar only (DD/MM + seconds)', '%d/%m/%Y %H:%M:%S', 1, true, true);
+    }
     this.menu.addMenuItem(presets);
 
     this.menu.connect('open-state-changed', (_menu, open) => {
@@ -194,7 +206,8 @@ export default class NumericClockExtension extends Extension {
     this._stageAddedId = 0;
     this._stageRemovedId = 0;
     this._settingsChangedIds = [];
-    this._textSignalIds = []; // [ [actor, id], ... ]
+    this._textSignalIds = [];
+    this._clickSignalIds = [];
   }
 
   _collectClockLabels() {
@@ -227,6 +240,34 @@ export default class NumericClockExtension extends Extension {
       ct.set_use_markup(false);
   }
 
+  _hookClockClick(lab) {
+    if (!lab || lab[CLICK_HOOKED] || !this._indicator) return;
+    lab[CLICK_HOOKED] = true;
+    lab.reactive = true;
+    lab.track_hover = true;
+    const id = lab.connect('button-press-event', (_actor, event) => {
+      if (!this._settings?.get_boolean('clock-secondary-opens-menu'))
+        return Clutter.EVENT_PROPAGATE;
+      const btn = event.get_button();
+      if (btn === Clutter.BUTTON_SECONDARY || btn === Clutter.BUTTON_MIDDLE) {
+        this._indicator.openQuickMenu();
+        return Clutter.EVENT_STOP;
+      }
+      return Clutter.EVENT_PROPAGATE;
+    });
+    this._clickSignalIds.push([lab, id]);
+    if (this._settings?.get_boolean('clock-secondary-opens-menu') &&
+        typeof lab.set_tooltip_text === 'function')
+      lab.set_tooltip_text('Right-click for Numeric Clock menu');
+  }
+
+  _unhookClockClick(lab) {
+    if (!lab) return;
+    try { delete lab[CLICK_HOOKED]; } catch {}
+    if (typeof lab.set_tooltip_text === 'function')
+      lab.set_tooltip_text(null);
+  }
+
   _applyTo(lab) {
     if (!lab) return;
     this._forcePlain(lab);
@@ -243,11 +284,21 @@ export default class NumericClockExtension extends Extension {
       });
       this._textSignalIds.push([ct, id]);
     }
+    this._hookClockClick(lab);
+  }
+
+  _refreshClockTooltips() {
+    const showTip = this._settings.get_boolean('clock-secondary-opens-menu');
+    for (const lab of this._collectClockLabels()) {
+      if (typeof lab.set_tooltip_text !== 'function') continue;
+      lab.set_tooltip_text(showTip ? 'Right-click for Numeric Clock menu' : null);
+    }
   }
 
   _updateAllNow() {
     for (const lab of this._collectClockLabels())
       this._applyTo(lab);
+    this._refreshClockTooltips();
   }
 
   _restartTimer() {
@@ -304,6 +355,7 @@ export default class NumericClockExtension extends Extension {
       this._settings.connect('changed::smooth-second', () => this._restartTimer()),
       this._settings.connect('changed::only-topbar', () => this._updateAllNow()),
       this._settings.connect('changed::show-panel-icon', () => this._syncIndicator()),
+      this._settings.connect('changed::clock-secondary-opens-menu', () => this._refreshClockTooltips()),
     );
     this._stageAddedId = connectStageSignal(global.stage, 'added', () => this._updateAllNow());
     this._stageRemovedId = connectStageSignal(global.stage, 'removed', () => this._updateAllNow());
@@ -336,6 +388,12 @@ export default class NumericClockExtension extends Extension {
     }
     this._textSignalIds = [];
 
+    for (const [lab, id] of this._clickSignalIds) {
+      try { lab.disconnect(id); } catch {}
+      this._unhookClockClick(lab);
+    }
+    this._clickSignalIds = [];
+
     this._restoreDefaultClocks();
     this._settings = null;
   }
@@ -355,6 +413,7 @@ export default class NumericClockExtension extends Extension {
         const ct = lab.clutter_text;
         if (ct && ct[HOOKED]) delete ct[HOOKED];
       } catch {}
+      this._unhookClockClick(lab);
     }
   }
 }

--- a/src/icons/numeric-clock-symbolic.svg
+++ b/src/icons/numeric-clock-symbolic.svg
@@ -1,6 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <path fill="currentColor" d="M8 1.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13Zm0 1a5.5 5.5 0 1 1 0 11 5.5 5.5 0 0 1 0-11Z"/>
-  <path fill="currentColor" d="M8 3.25a.75.75 0 0 0-.75.75v3.9c0 .2.08.39.22.53l2.2 2.2a.75.75 0 1 0 1.06-1.06L8.75 7.56V4a.75.75 0 0 0-.75-.75Z"/>
-  <path fill="currentColor" d="M4.1 11.35a.55.55 0 0 0-.08.78l.35.35h7.26l.35-.35a.55.55 0 0 0-.78-.78l-.22.22H4.9l-.22-.22Z"/>
-  <path fill="currentColor" d="M5.15 9.55h.9v.7h-.9v-.7Zm1.35 0h.9v.7h-.9v-.7Zm1.35 0h.9v.7h-.9v-.7Zm1.35 0h.9v.7h-.9v-.7Z"/>
+  <path fill="currentColor" d="M3 2.5h10a1.5 1.5 0 0 1 1.5 1.5v8a1.5 1.5 0 0 1-1.5 1.5H3A1.5 1.5 0 0 1 1.5 12V4A1.5 1.5 0 0 1 3 2.5Zm0 1a.5.5 0 0 0-.5.5v8a.5.5 0 0 0 .5.5h10a.5.5 0 0 0 .5-.5V4a.5.5 0 0 0-.5-.5H3Z"/>
+  <path fill="currentColor" d="M4.25 5.25h1.1v1.1h-1.1v-1.1Zm1.85 0h1.1v1.1H6.1v-1.1Zm1.85 0h1.1v1.1h-1.1v-1.1Zm2.95 0h1.1v1.1h-1.1v-1.1ZM4.25 7.15h1.1v1.1h-1.1v-1.1Zm1.85 0h1.1v1.1H6.1v-1.1Zm1.85 0h1.1v1.1h-1.1v-1.1Zm2.95 0h1.1v1.1h-1.1v-1.1Z"/>
+  <path fill="currentColor" d="M7.15 9.9h1.7a.55.55 0 0 1 0 1.1H7.15a.55.55 0 0 1 0-1.1Z"/>
 </svg>

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -10,8 +10,8 @@
     "49",
     "50"
   ],
-  "version": 24,
-  "version-name": "17.4.0 45.50",
+  "version": 25,
+  "version-name": "17.4.1 45.50",
   "icon": "numeric-clock-symbolic",
   "settings-schema": "org.gnome.shell.extensions.numeric-clock",
   "gettext-domain": "numeric-clock",

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -5,6 +5,7 @@ import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import Gettext from 'gettext';
 import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import { FORMAT_PRESETS, applyPresetToSettings } from './presets.js';
 
 const REPO_URL = 'https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock';
 const EMAIL = 'nickotmazgin.dev@gmail.com';
@@ -14,8 +15,8 @@ export default class NumericClockPrefs extends ExtensionPreferences {
   fillPreferencesWindow(window) {
     const settings = this.getSettings();
     const metadata = this.metadata || {};
-    window.default_width = 520;
-    window.default_height = 420;
+    window.default_width = 560;
+    window.default_height = 520;
 
     const _ = Gettext.domain('numeric-clock').gettext;
 
@@ -40,7 +41,7 @@ export default class NumericClockPrefs extends ExtensionPreferences {
 
     const rowPreview = new Adw.ActionRow({
       title: _('Preview'),
-      subtitle: _('Live clock sample — add %S or %T in the format string to show seconds'),
+      subtitle: _('Live sample — uses your system locale and timezone'),
     });
     const preview = new Gtk.Label({ hexpand: true, selectable: true, xalign: 1 });
     let previewTimer = 0;
@@ -80,7 +81,10 @@ export default class NumericClockPrefs extends ExtensionPreferences {
     rowInt.activatable_widget = spin;
     group.add(rowInt);
 
-    const rowOnly = new Adw.ActionRow({ title: _('Only override top bar DateMenu') });
+    const rowOnly = new Adw.ActionRow({
+      title: _('Only override top bar DateMenu'),
+      subtitle: _('Recommended. Turning off may affect other panel clocks on some desktops.'),
+    });
     const swOnly = new Gtk.Switch({ active: settings.get_boolean('only-topbar') });
     swOnly.connect('notify::active', w => settings.set_boolean('only-topbar', w.active));
     rowOnly.add_suffix(swOnly);
@@ -96,7 +100,7 @@ export default class NumericClockPrefs extends ExtensionPreferences {
 
     const rowIcon = new Adw.ActionRow({
       title: _('Show panel access icon'),
-      subtitle: _('Clock icon in the top bar — click for preferences, presets, and copy time'),
+      subtitle: _('Digital clock icon in the top bar — click for preferences, presets, and copy time'),
     });
     const swIcon = new Gtk.Switch({ active: settings.get_boolean('show-panel-icon') });
     swIcon.connect('notify::active', w => settings.set_boolean('show-panel-icon', w.active));
@@ -104,34 +108,54 @@ export default class NumericClockPrefs extends ExtensionPreferences {
     rowIcon.activatable_widget = swIcon;
     group.add(rowIcon);
 
-    const rowPresets = new Adw.ActionRow({
-      title: _('Presets'),
-      subtitle: _('Quick formats for any timezone — uses your system clock (e.g. Asia/Jerusalem)'),
+    const rowClockMenu = new Adw.ActionRow({
+      title: _('Right-click clock for quick menu'),
+      subtitle: _('Right-click or middle-click the formatted clock. Left-click still opens the GNOME calendar.'),
     });
-    const btnDefault = new Gtk.Button({ label: _('Default'), tooltip_text: _('%d/%m/%Y %H:%M:%S') });
-    const btnSeconds = new Gtk.Button({ label: _('Seconds'), tooltip_text: _('%A %d/%m/%Y %H:%M:%S') });
-    const btnDdMm = new Gtk.Button({ label: _('DD/MM + seconds'), tooltip_text: _('%d/%m/%Y %H:%M:%S — top bar only') });
-    const applyPreset = (fmt, interval, smooth, onlyTopbar) => {
-      settings.set_string('format-string', fmt);
-      settings.set_int('update-interval', interval);
-      settings.set_boolean('smooth-second', smooth);
-      if (onlyTopbar !== undefined)
-        settings.set_boolean('only-topbar', onlyTopbar);
+    const swClockMenu = new Gtk.Switch({ active: settings.get_boolean('clock-secondary-opens-menu') });
+    swClockMenu.connect('notify::active', w => settings.set_boolean('clock-secondary-opens-menu', w.active));
+    rowClockMenu.add_suffix(swClockMenu);
+    rowClockMenu.activatable_widget = swClockMenu;
+    group.add(rowClockMenu);
+
+    pageSettings.add(group);
+
+    const groupPresets = new Adw.PreferencesGroup({
+      title: _('Format presets'),
+      description: _('One-click formats — uses your system locale and timezone worldwide'),
+    });
+    const presetGrid = new Gtk.FlowBox({
+      selection_mode: Gtk.SelectionMode.NONE,
+      column_spacing: 8,
+      row_spacing: 8,
+      max_children_per_line: 3,
+      homogeneous: true,
+    });
+    const applyPreset = preset => {
+      applyPresetToSettings(settings, preset);
       entry.text = settings.get_string('format-string');
       if (typeof spin.set_value === 'function')
-        spin.set_value(interval);
+        spin.set_value(settings.get_int('update-interval'));
+      swOnly.active = settings.get_boolean('only-topbar');
+      swSmooth.active = settings.get_boolean('smooth-second');
       refreshPreview();
     };
-    btnDefault.connect('clicked', () => applyPreset('%d/%m/%Y %H:%M:%S', 1, true));
-    btnSeconds.connect('clicked', () => applyPreset('%A %d/%m/%Y %H:%M:%S', 1, true));
-    btnDdMm.connect('clicked', () => applyPreset('%d/%m/%Y %H:%M:%S', 1, true, true));
-    const btnBox = new Gtk.Box({ spacing: 6 });
-    btnBox.append(btnDefault);
-    btnBox.append(btnSeconds);
-    btnBox.append(btnDdMm);
-    rowPresets.add_suffix(btnBox);
-    group.add(rowPresets);
+    for (const preset of FORMAT_PRESETS) {
+      const btn = new Gtk.Button({
+        label: _(preset.label),
+        tooltip_text: preset.fmt,
+      });
+      btn.connect('clicked', () => applyPreset(preset));
+      const boxChild = new Gtk.FlowBoxChild();
+      boxChild.child = btn;
+      presetGrid.append(boxChild);
+    }
+    const presetRow = new Adw.ActionRow({ title: _('Apply preset') });
+    presetRow.add_suffix(presetGrid);
+    groupPresets.add(presetRow);
+    pageSettings.add(groupPresets);
 
+    const groupReset = new Adw.PreferencesGroup();
     const rowReset = new Adw.ActionRow({ title: _('Reset to defaults') });
     const btnReset = new Gtk.Button({ label: _('Reset') });
     btnReset.connect('clicked', () => {
@@ -141,19 +165,20 @@ export default class NumericClockPrefs extends ExtensionPreferences {
         settings.reset('smooth-second');
         settings.reset('only-topbar');
         settings.reset('show-panel-icon');
+        settings.reset('clock-secondary-opens-menu');
         entry.text = settings.get_string('format-string');
         if (typeof spin.set_value === 'function')
           spin.set_value(settings.get_int('update-interval'));
         swOnly.active = settings.get_boolean('only-topbar');
         swSmooth.active = settings.get_boolean('smooth-second');
         swIcon.active = settings.get_boolean('show-panel-icon');
+        swClockMenu.active = settings.get_boolean('clock-secondary-opens-menu');
         refreshPreview();
       } catch (_) {}
     });
     rowReset.add_suffix(btnReset);
-    group.add(rowReset);
-
-    pageSettings.add(group);
+    groupReset.add(rowReset);
+    pageSettings.add(groupReset);
 
     const pageAbout = new Adw.PreferencesPage({
       title: _('About'),
@@ -179,7 +204,7 @@ export default class NumericClockPrefs extends ExtensionPreferences {
     }));
     groupInfo.add(new Adw.ActionRow({
       title: _('Description'),
-      subtitle: _('Numeric DD/MM/YYYY 24-hour top-bar clock with optional seconds and live preview.'),
+      subtitle: _('International numeric top-bar clock — configurable date/time format, panel icon, and live preview.'),
     }));
     pageAbout.add(groupInfo);
 

--- a/src/presets.js
+++ b/src/presets.js
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+// Shared format presets — no GNOME Shell imports (safe for prefs + extension).
+
+/** @typedef {{ id: string, label: string, fmt: string, interval: number, smooth: boolean, onlyTopbar?: boolean }} FormatPreset */
+
+/** @type {FormatPreset[]} */
+export const FORMAT_PRESETS = [
+  {
+    id: 'intl-full',
+    label: 'International (DD/MM + seconds)',
+    fmt: '%d/%m/%Y %H:%M:%S',
+    interval: 1,
+    smooth: true,
+  },
+  {
+    id: 'weekday',
+    label: 'Weekday + seconds',
+    fmt: '%A %d/%m/%Y %H:%M:%S',
+    interval: 1,
+    smooth: true,
+  },
+  {
+    id: 'compact',
+    label: 'Compact (DD/MM HH:MM)',
+    fmt: '%d/%m %H:%M',
+    interval: 60,
+    smooth: false,
+  },
+  {
+    id: 'time-only',
+    label: 'Time only (24-hour)',
+    fmt: '%H:%M:%S',
+    interval: 1,
+    smooth: true,
+  },
+  {
+    id: 'iso',
+    label: 'ISO 8601',
+    fmt: '%Y-%m-%d %H:%M:%S',
+    interval: 1,
+    smooth: true,
+  },
+  {
+    id: 'us-12h',
+    label: 'US date + 12-hour',
+    fmt: '%m/%d/%Y %I:%M:%S %p',
+    interval: 1,
+    smooth: true,
+  },
+  {
+    id: 'topbar-only',
+    label: 'Top bar only (DD/MM + seconds)',
+    fmt: '%d/%m/%Y %H:%M:%S',
+    interval: 1,
+    smooth: true,
+    onlyTopbar: true,
+  },
+];
+
+export function applyPresetToSettings(settings, preset) {
+  settings.set_string('format-string', preset.fmt);
+  settings.set_int('update-interval', preset.interval);
+  settings.set_boolean('smooth-second', preset.smooth);
+  if (preset.onlyTopbar !== undefined)
+    settings.set_boolean('only-topbar', preset.onlyTopbar);
+}

--- a/src/schemas/org.gnome.shell.extensions.numeric-clock.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.numeric-clock.gschema.xml
@@ -4,7 +4,7 @@
     <key name="format-string" type="s">
       <default>'%d/%m/%Y %H:%M:%S'</default>
       <summary>Clock format</summary>
-      <description>strftime format string for the top bar clock. Uses the system timezone (e.g. Asia/Jerusalem).</description>
+      <description>strftime format string for the top bar clock. Uses your system locale and timezone.</description>
     </key>
     <key name="update-interval" type="i">
       <default>1</default>
@@ -26,6 +26,11 @@
       <default>true</default>
       <summary>Show panel access icon</summary>
       <description>Display a clock icon in the top bar for quick preferences, presets, and copy-time access.</description>
+    </key>
+    <key name="clock-secondary-opens-menu" type="b">
+      <default>true</default>
+      <summary>Right-click clock for quick menu</summary>
+      <description>Right-click or middle-click the formatted top-bar clock to open the Numeric Clock quick menu. Left-click still opens the GNOME calendar.</description>
     </key>
   </schema>
 </schemalist>

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -44,8 +44,13 @@ pack_dir() {
     (cd "$tmpdir" && zip -qr "$basezip" .)
   fi
 
-  if [[ -d "$tmpdir/icons" ]] && command -v zip >/dev/null 2>&1; then
-    (cd "$tmpdir" && zip -qr "$basezip" icons/)
+  if command -v zip >/dev/null 2>&1; then
+    if [[ -d "$tmpdir/icons" ]]; then
+      (cd "$tmpdir" && zip -qr "$basezip" icons/)
+    fi
+    if [[ -f "$tmpdir/presets.js" ]]; then
+      (cd "$tmpdir" && zip -q "$basezip" presets.js)
+    fi
   fi
 
   local dest="$dist/${uuid}.v${version}.shell-extension.zip"

--- a/tools/validate.sh
+++ b/tools/validate.sh
@@ -39,6 +39,7 @@ main() {
     check_zip_has   "$esm_zip" metadata.json
     check_zip_has   "$esm_zip" extension.js
     check_zip_has   "$esm_zip" prefs.js
+    check_zip_has   "$esm_zip" presets.js
     check_zip_has   "$esm_zip" icons/numeric-clock-symbolic.svg
     check_zip_has   "$esm_zip" schemas/org.gnome.shell.extensions.numeric-clock.gschema.xml
     check_zip_lacks "$esm_zip" tools/build.sh


### PR DESCRIPTION
## Summary
- **Digital panel icon** redesign (readable at 16px)
- **7 international presets** via shared `presets.js` (ISO, compact, time-only, US 12h, etc.)
- **Tooltip** on panel icon; **right-click/middle-click** formatted clock for quick menu
- **PRIVACY.md** — local-only, no network, Zorin/GNOME compliant
- README reframed for **worldwide** use (removed region-specific framing)
- Menu symbolic icons; `only-topbar` safety note in prefs

## Test plan
- [x] `./tools/build.sh` && `./tools/validate.sh` pass
- [ ] Install zip, reload Shell, verify icon + menu + right-click clock
- [ ] Confirm left-click still opens GNOME calendar


Made with [Cursor](https://cursor.com)