### PR TITLE
chore: fix release-publish startup_failure (drop attestations)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
-  attestations: write
 
 jobs:
   publish:
@@ -57,9 +55,3 @@ jobs:
             gh release create "$TAG" "$ZIP" --title "$TITLE" --notes-file /tmp/release-notes.md
           fi
 
-      - name: Attest release zip (Sigstore)
-        continue-on-error: true
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-path: ${{ steps.meta.outputs.zip }}
-          push-to-registry: false


### PR DESCRIPTION
Remove attestations permission and Sigstore step that caused GitHub Actions startup_failure on tag push.

Made with [Cursor](https://cursor.com)