### PR TITLE
fix: presets submenu icon crash on enable (v17.4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v17.4.2 — 2026-06-11
+
+**Fix extension enable crash on quick-presets submenu.**
+
+- `PopupSubMenuMenuItem` now passes `wantIcon=true` so `presets.icon` exists on GNOME 45–50
+- Extension enables cleanly again after disable or Shell reload
+
+> **Recommended upgrade** from v17.4.1 if enable failed with `TypeError: presets.icon is undefined`.
+
 ## v17.4.1 — 2026-06-11
 
 **International polish, refined icon, and easier access.**

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 
 A lightweight GNOME Shell extension that replaces the top-bar clock with a **numeric, fully configurable** format — ideal for **DD/MM/YYYY**, **ISO 8601**, **24-hour**, or **12-hour** time with optional **seconds**, anywhere in the world.
 
-**Latest:** v17.4.1 — ESM build v25 for **GNOME 45–50** (Shell 46 tested on Zorin OS 18.1)
+**Latest:** v17.4.2 — ESM build v26 for **GNOME 45–50** (Shell 46 tested on Zorin OS 18.1)
 
-> Download only [v17.4.1](https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock/releases/latest). Older releases are kept for history and marked superseded.
+> Download only [v17.4.2](https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock/releases/latest). Older releases are kept for history and marked superseded.
 
 **UUID:** `numeric-clock@nickotmazgin`
 
@@ -63,7 +63,7 @@ A lightweight GNOME Shell extension that replaces the top-bar clock with a **num
 
 | GNOME | Status | Extension version | Notes |
 | ----- | ------ | ----------------: | ----- |
-| **45–50** | **Supported** | 25 | ESM build; do not ship `schemas/gschemas.compiled` |
+| **45–50** | **Supported** | 26 | ESM build; do not ship `schemas/gschemas.compiled` |
 | **42–44** | **Discontinued** | — | No longer built or maintained |
 
 **Minimum requirement:** GNOME Shell **45**.
@@ -77,7 +77,7 @@ Works on **Zorin OS**, Ubuntu, Fedora, and other GNOME-based distributions that 
 ### From GitHub release (recommended)
 
 ```bash
-gnome-extensions install --force dist/numeric-clock@nickotmazgin.v25.shell-extension.zip
+gnome-extensions install --force dist/numeric-clock@nickotmazgin.v26.shell-extension.zip
 gnome-extensions enable numeric-clock@nickotmazgin
 gnome-extensions prefs numeric-clock@nickotmazgin
 ```
@@ -87,7 +87,7 @@ gnome-extensions prefs numeric-clock@nickotmazgin
 ```bash
 ./tools/build.sh
 ./tools/validate.sh
-gnome-extensions install --force dist/numeric-clock@nickotmazgin.v25.shell-extension.zip
+gnome-extensions install --force dist/numeric-clock@nickotmazgin.v26.shell-extension.zip
 gnome-extensions enable numeric-clock@nickotmazgin
 ```
 
@@ -184,7 +184,7 @@ journalctl --user -b 0 -o cat | grep -i numeric-clock
 ## Packaging & releases (maintainers)
 
 ```bash
-./tools/build.sh    # -> dist/numeric-clock@nickotmazgin.v25.shell-extension.zip (GNOME 45–50)
+./tools/build.sh    # -> dist/numeric-clock@nickotmazgin.v26.shell-extension.zip (GNOME 45–50)
 ./tools/validate.sh
 ```
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -174,8 +174,9 @@ class NumericClockIndicator extends PanelMenu.Button {
     });
     this.menu.addMenuItem(copyItem);
 
-    const presets = new PopupMenu.PopupSubMenuMenuItem('Quick presets');
-    presets.icon.icon_name = 'document-edit-symbolic';
+    const presets = new PopupMenu.PopupSubMenuMenuItem('Quick presets', true);
+    if (presets.icon)
+      presets.icon.icon_name = 'document-edit-symbolic';
     for (const preset of FORMAT_PRESETS) {
       const item = new PopupMenu.PopupMenuItem(preset.label);
       item.connect('activate', () => {

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -10,8 +10,8 @@
     "49",
     "50"
   ],
-  "version": 25,
-  "version-name": "17.4.1 45.50",
+  "version": 26,
+  "version-name": "17.4.2 45.50",
   "icon": "numeric-clock-symbolic",
   "settings-schema": "org.gnome.shell.extensions.numeric-clock",
   "gettext-domain": "numeric-clock",


### PR DESCRIPTION
## Summary
- Fix `TypeError: presets.icon is undefined` on extension enable
- `PopupSubMenuMenuItem('Quick presets', true)` — matches EaseHub pattern

## Test plan
- [x] validate.sh passes
- [ ] Enable extension after disable — no journal errors


Made with [Cursor](https://cursor.com)