### PR TITLE
release: v17.4.3 — panel icon, prefs layout, release CI fix

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -14,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y zip libglib2.0-bin
+          sudo apt-get install -y zip libglib2.0-bin gnome-shell-extensions
 
       - name: Build and validate release zip
         run: |
@@ -54,4 +53,3 @@ jobs:
           else
             gh release create "$TAG" "$ZIP" --title "$TITLE" --notes-file /tmp/release-notes.md
           fi
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v17.4.3 — 2026-06-11
+
+**UI fixes, clearer panel icon, and release CI repair.**
+
+- Redesign panel icon as a **bold analog clock** (more visible, no keyboard-like segments)
+- Add `stylesheet.css` for slightly larger panel icon (18px)
+- Fix preferences presets layout — each preset is a normal horizontal row with **Apply** button (no vertical/garbled text)
+- Fix release CI `startup_failure` — pin `actions/checkout` SHA (same as validate workflow) and install `gnome-shell-extensions` on CI
+
+> **Recommended upgrade** from v17.4.2 and earlier.
+
 ## v17.4.2 — 2026-06-11
 
 **Fix extension enable crash on quick-presets submenu.**

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 
 A lightweight GNOME Shell extension that replaces the top-bar clock with a **numeric, fully configurable** format — ideal for **DD/MM/YYYY**, **ISO 8601**, **24-hour**, or **12-hour** time with optional **seconds**, anywhere in the world.
 
-**Latest:** v17.4.2 — ESM build v26 for **GNOME 45–50** (Shell 46 tested on Zorin OS 18.1)
+**Latest:** v17.4.3 — ESM build v27 for **GNOME 45–50** (Shell 46 tested on Zorin OS 18.1)
 
-> Download only [v17.4.2](https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock/releases/latest). Older releases are kept for history and marked superseded.
+> Download only [v17.4.3](https://github.com/nickotmazgin/Linux-Numeric-Date-And-Clock/releases/latest). Older releases are kept for history and marked superseded.
 
 **UUID:** `numeric-clock@nickotmazgin`
 
@@ -63,7 +63,7 @@ A lightweight GNOME Shell extension that replaces the top-bar clock with a **num
 
 | GNOME | Status | Extension version | Notes |
 | ----- | ------ | ----------------: | ----- |
-| **45–50** | **Supported** | 26 | ESM build; do not ship `schemas/gschemas.compiled` |
+| **45–50** | **Supported** | 27 | ESM build; do not ship `schemas/gschemas.compiled` |
 | **42–44** | **Discontinued** | — | No longer built or maintained |
 
 **Minimum requirement:** GNOME Shell **45**.
@@ -77,7 +77,7 @@ Works on **Zorin OS**, Ubuntu, Fedora, and other GNOME-based distributions that 
 ### From GitHub release (recommended)
 
 ```bash
-gnome-extensions install --force dist/numeric-clock@nickotmazgin.v26.shell-extension.zip
+gnome-extensions install --force dist/numeric-clock@nickotmazgin.v27.shell-extension.zip
 gnome-extensions enable numeric-clock@nickotmazgin
 gnome-extensions prefs numeric-clock@nickotmazgin
 ```
@@ -87,7 +87,7 @@ gnome-extensions prefs numeric-clock@nickotmazgin
 ```bash
 ./tools/build.sh
 ./tools/validate.sh
-gnome-extensions install --force dist/numeric-clock@nickotmazgin.v26.shell-extension.zip
+gnome-extensions install --force dist/numeric-clock@nickotmazgin.v27.shell-extension.zip
 gnome-extensions enable numeric-clock@nickotmazgin
 ```
 
@@ -184,7 +184,7 @@ journalctl --user -b 0 -o cat | grep -i numeric-clock
 ## Packaging & releases (maintainers)
 
 ```bash
-./tools/build.sh    # -> dist/numeric-clock@nickotmazgin.v26.shell-extension.zip (GNOME 45–50)
+./tools/build.sh    # -> dist/numeric-clock@nickotmazgin.v27.shell-extension.zip (GNOME 45–50)
 ./tools/validate.sh
 ```
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -95,6 +95,7 @@ const NumericClockIndicator = GObject.registerClass(
 class NumericClockIndicator extends PanelMenu.Button {
   _init(settings, extensionPath, openPrefs) {
     super._init(0.0, 'Numeric Clock');
+    this.add_style_class_name('numeric-clock-panel');
     this._settings = settings;
     this._openPrefs = openPrefs;
     this._timeLabel = null;
@@ -202,6 +203,7 @@ export default class NumericClockExtension extends Extension {
     super(uuid);
     this._settings = null;
     this._indicator = null;
+    this._stylesheet = null;
     this._timeoutId = 0;
     this._msTimeoutId = 0;
     this._stageAddedId = 0;
@@ -340,8 +342,26 @@ export default class NumericClockExtension extends Extension {
     this._indicator.visible = show;
   }
 
+  _loadStylesheet() {
+    const path = GLib.build_filenamev([this.path, 'stylesheet.css']);
+    const file = Gio.File.new_for_path(path);
+    if (!file.query_exists(null))
+      return;
+    const theme = St.ThemeContext.get_for_stage(global.stage);
+    this._stylesheet = theme.load_stylesheet(file);
+  }
+
+  _unloadStylesheet() {
+    if (!this._stylesheet)
+      return;
+    const theme = St.ThemeContext.get_for_stage(global.stage);
+    theme.unload_stylesheet(this._stylesheet);
+    this._stylesheet = null;
+  }
+
   enable() {
     this._settings = this.getSettings();
+    this._loadStylesheet();
 
     this._indicator = new NumericClockIndicator(
       this._settings,
@@ -365,6 +385,8 @@ export default class NumericClockExtension extends Extension {
   }
 
   disable() {
+    this._unloadStylesheet();
+
     if (this._indicator) {
       this._indicator.destroy();
       this._indicator = null;

--- a/src/icons/numeric-clock-symbolic.svg
+++ b/src/icons/numeric-clock-symbolic.svg
@@ -1,5 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <path fill="currentColor" d="M3 2.5h10a1.5 1.5 0 0 1 1.5 1.5v8a1.5 1.5 0 0 1-1.5 1.5H3A1.5 1.5 0 0 1 1.5 12V4A1.5 1.5 0 0 1 3 2.5Zm0 1a.5.5 0 0 0-.5.5v8a.5.5 0 0 0 .5.5h10a.5.5 0 0 0 .5-.5V4a.5.5 0 0 0-.5-.5H3Z"/>
-  <path fill="currentColor" d="M4.25 5.25h1.1v1.1h-1.1v-1.1Zm1.85 0h1.1v1.1H6.1v-1.1Zm1.85 0h1.1v1.1h-1.1v-1.1Zm2.95 0h1.1v1.1h-1.1v-1.1ZM4.25 7.15h1.1v1.1h-1.1v-1.1Zm1.85 0h1.1v1.1H6.1v-1.1Zm1.85 0h1.1v1.1h-1.1v-1.1Zm2.95 0h1.1v1.1h-1.1v-1.1Z"/>
-  <path fill="currentColor" d="M7.15 9.9h1.7a.55.55 0 0 1 0 1.1H7.15a.55.55 0 0 1 0-1.1Z"/>
+  <path fill="currentColor" fill-rule="evenodd" d="M8 1.1a6.9 6.9 0 1 0 0 13.8 6.9 6.9 0 0 0 0-13.8Zm0 1.2a5.7 5.7 0 1 1 0 11.4 5.7 5.7 0 0 1 0-11.4Z"/>
+  <path fill="currentColor" d="M7.55 3.05h1v1.45h-1V3.05Z"/>
+  <path fill="currentColor" d="M7.45 7.55V5.05a.55.55 0 0 1 1.1 0v2.5l1.75 1.75a.55.55 0 1 1-.78.78L7.45 7.55Z"/>
+  <circle fill="currentColor" cx="8" cy="8" r="1.05"/>
 </svg>

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -10,8 +10,8 @@
     "49",
     "50"
   ],
-  "version": 26,
-  "version-name": "17.4.2 45.50",
+  "version": 27,
+  "version-name": "17.4.3 45.50",
   "icon": "numeric-clock-symbolic",
   "settings-schema": "org.gnome.shell.extensions.numeric-clock",
   "gettext-domain": "numeric-clock",

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -100,7 +100,7 @@ export default class NumericClockPrefs extends ExtensionPreferences {
 
     const rowIcon = new Adw.ActionRow({
       title: _('Show panel access icon'),
-      subtitle: _('Digital clock icon in the top bar — click for preferences, presets, and copy time'),
+      subtitle: _('Clock icon in the top bar — click for preferences, presets, and copy time'),
     });
     const swIcon = new Gtk.Switch({ active: settings.get_boolean('show-panel-icon') });
     swIcon.connect('notify::active', w => settings.set_boolean('show-panel-icon', w.active));
@@ -124,13 +124,6 @@ export default class NumericClockPrefs extends ExtensionPreferences {
       title: _('Format presets'),
       description: _('One-click formats — uses your system locale and timezone worldwide'),
     });
-    const presetGrid = new Gtk.FlowBox({
-      selection_mode: Gtk.SelectionMode.NONE,
-      column_spacing: 8,
-      row_spacing: 8,
-      max_children_per_line: 3,
-      homogeneous: true,
-    });
     const applyPreset = preset => {
       applyPresetToSettings(settings, preset);
       entry.text = settings.get_string('format-string');
@@ -141,18 +134,16 @@ export default class NumericClockPrefs extends ExtensionPreferences {
       refreshPreview();
     };
     for (const preset of FORMAT_PRESETS) {
-      const btn = new Gtk.Button({
-        label: _(preset.label),
-        tooltip_text: preset.fmt,
+      const row = new Adw.ActionRow({
+        title: _(preset.label),
+        subtitle: preset.fmt,
       });
+      const btn = new Gtk.Button({ label: _('Apply'), valign: Gtk.Align.CENTER });
       btn.connect('clicked', () => applyPreset(preset));
-      const boxChild = new Gtk.FlowBoxChild();
-      boxChild.child = btn;
-      presetGrid.append(boxChild);
+      row.add_suffix(btn);
+      row.activatable_widget = btn;
+      groupPresets.add(row);
     }
-    const presetRow = new Adw.ActionRow({ title: _('Apply preset') });
-    presetRow.add_suffix(presetGrid);
-    groupPresets.add(presetRow);
     pageSettings.add(groupPresets);
 
     const groupReset = new Adw.PreferencesGroup();

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -1,0 +1,8 @@
+/* Numeric Clock — panel icon visibility */
+.numeric-clock-icon {
+  icon-size: 18px;
+}
+
+.panel-button.numeric-clock-panel .numeric-clock-icon {
+  icon-size: 18px;
+}

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -51,6 +51,9 @@ pack_dir() {
     if [[ -f "$tmpdir/presets.js" ]]; then
       (cd "$tmpdir" && zip -q "$basezip" presets.js)
     fi
+    if [[ -f "$tmpdir/stylesheet.css" ]]; then
+      (cd "$tmpdir" && zip -q "$basezip" stylesheet.css)
+    fi
   fi
 
   local dest="$dist/${uuid}.v${version}.shell-extension.zip"

--- a/tools/validate.sh
+++ b/tools/validate.sh
@@ -41,6 +41,7 @@ main() {
     check_zip_has   "$esm_zip" prefs.js
     check_zip_has   "$esm_zip" presets.js
     check_zip_has   "$esm_zip" icons/numeric-clock-symbolic.svg
+    check_zip_has   "$esm_zip" stylesheet.css
     check_zip_has   "$esm_zip" schemas/org.gnome.shell.extensions.numeric-clock.gschema.xml
     check_zip_lacks "$esm_zip" tools/build.sh
     check_zip_lacks "$esm_zip" .env


### PR DESCRIPTION
## Summary
- **Panel icon:** bold analog clock (not keyboard-like) + 18px stylesheet
- **Preferences:** preset rows are horizontal ActionRows with Apply buttons (fixes vertical/garbled text)
- **Release CI:** pin `actions/checkout` SHA + install `gnome-shell-extensions` (fixes `startup_failure`)

## Test plan
- [x] `./tools/build.sh` && `./tools/validate.sh`
- [ ] Reload Shell — enable extension, no journal TypeError
- [ ] Open prefs — presets read normally left-to-right
- [ ] Tag push triggers Release Publish successfully


Made with [Cursor](https://cursor.com)