### PR TITLE
chore: gitignore Playwright MCP local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ Thumbs.db
 .vscode/
 .idea/
 *.code-workspace
+.playwright-mcp/
 
 # Caches
 __pycache__/


### PR DESCRIPTION
## Summary
- Ignore `.playwright-mcp/` (Playwright MCP local browser snapshots and console logs)
- Prevents accidental commit of personal browsing context from MCP sessions

## Test plan
- [x] `git check-ignore .playwright-mcp/` passes locally
- [x] No other files changed

Made with [Cursor](https://cursor.com)